### PR TITLE
X.509 disintegration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The typical Koji build system deployment consists of one or more Builders, a Web
 * [koji::hub](#kojihub-class)
 * [koji::hub::x509](#kojihubx509-class)
 * [koji::kojira](#kojikojira-class)
+* [koji::kojira::x509](#kojikojirax509-class)
 * [koji::utils](#kojiutils-class)
 * [koji::web](#kojiweb-class)
 
@@ -423,16 +424,6 @@ This class manages the Kojira component on a host.
 ##### `hub`
 URL of your Koji Hub service.
 
-#####  `hub_ca_cert_content`, `hub_ca_cert_source`
-Literal string or Puppet source URI providing the CA certificate which signed
-the Koji Hub certificate.  This must be in PEM format and include all
-intermediate CA certificates, sorted and concatenated from the leaf CA to the
-root CA.
-
-#####  `kojira_cert_content`, `kojira_cert_source`
-Literal string or Puppet source URI providing the Kojira component's identity
-certificate which must be in PEM format.
-
 ##### `top_dir`
 Name of the directory containing the `'repos/'` directory.
 
@@ -457,6 +448,24 @@ Instance is to be started at boot.  Either `true` (default) or `false`.
 
 ##### `service`
 The service name of the Kojira daemon.
+
+
+#### koji::kojira::x509 class
+
+This class manages the X.509 certificates for Kojira.  It's use is optional and
+should only be included if you wish to use the integrated X.509 support offered
+by the [doubledog-openssl](https://github.com/jflorian/doubledog-openssl)
+module.
+
+#####  `hub_ca_cert_content`, `hub_ca_cert_source`
+Literal string or Puppet source URI providing the CA certificate which signed
+the Koji Hub certificate.  This must be in PEM format and include all
+intermediate CA certificates, sorted and concatenated from the leaf CA to the
+root CA.
+
+#####  `kojira_cert_content`, `kojira_cert_source`
+Literal string or Puppet source URI providing the Kojira component's identity
+certificate which must be in PEM format.
 
 
 #### koji::utils class

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The typical Koji build system deployment consists of one or more Builders, a Web
 * [koji::kojira::x509](#kojikojirax509-class)
 * [koji::utils](#kojiutils-class)
 * [koji::web](#kojiweb-class)
+* [koji::web::x509](#kojiwebx509-class)
 
 **Defined types:**
 
@@ -489,18 +490,8 @@ required.
 ##### `files_url`
 URL for accessing Koji's file resources.
 
-#####  `hub_ca_cert_content`, `hub_ca_cert_source`
-Literal string or Puppet source URI providing the CA certificate which signed
-the Koji Hub certificate.  This must be in PEM format and include all
-intermediate CA certificates, sorted and concatenated from the leaf CA to the
-root CA.
-
 ##### `hub_url`
 URL for accessing the Koji Hub's RPC services.
-
-#####  `web_cert_content`, `web_cert_source`
-Literal string or Puppet source URI providing the Koji Web's certificate.  This
-must be in PEM format.
 
 ##### `secret`
 Undocumented by the Koji project, but required.  Pass in a reasonably long
@@ -530,6 +521,24 @@ Name of the web theme that Koji is to use.  Content under
 files under `'/usr/share/koji-web/static/'`.  Any absent files will fall back
 to the normal files.  This module provides only the configuration to use
 *theme* and provides nothing to actually install *theme*.
+
+
+#### koji::web::x509 class
+
+This class manages the X.509 certificates the Koji Web component.  It's use is
+optional and should only be included if you wish to use the integrated X.509
+support offered by the
+[doubledog-openssl](https://github.com/jflorian/doubledog-openssl) module.
+
+#####  `hub_ca_cert_content`, `hub_ca_cert_source`
+Literal string or Puppet source URI providing the CA certificate which signed
+the Koji Hub certificate.  This must be in PEM format and include all
+intermediate CA certificates, sorted and concatenated from the leaf CA to the
+root CA.
+
+#####  `web_cert_content`, `web_cert_source`
+Literal string or Puppet source URI providing the Koji Web's certificate.  This
+must be in PEM format.
 
 
 ### Defined types

--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ The typical Koji build system deployment consists of one or more Builders, a Web
 
 ### Setup Requirements
 
+This module integrates and thus depends on several other Puppet modules to
+achieve a reliable solution.  At present these are:
+
+* [doubledog-apache](https://github.com/jflorian/doubledog-apache)
+* [doubledog-cron](https://github.com/jflorian/doubledog-cron)
+* [puppetlabs-concat](https://github.com/puppetlabs/puppetlabs-concat)
+* [puppetlabs-postgresql](https://github.com/puppetlabs/puppetlabs-postgresql)
+
+The following is optional (despite being listed as a requirement in the
+`metadata.json` file), unless you wish to use any of the integrated `*::x509`
+classes.  If you don't use those, you will either need to manage the X.509
+certificates separately (or help with the Kerberos support, below).
+
+* [doubledog-openssl](https://github.com/jflorian/doubledog-openssl)
+
+In the future, I intend to do more such disintegration and implement Kerberos
+support but, alas I only have so much time.  (Hint: PRs welcome!)
+
 ### Beginning with koji
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The typical Koji build system deployment consists of one or more Builders, a Web
 * [koji::gc](#kojigc-class)
 * [koji::httpd](#kojihttpd-class)
 * [koji::hub](#kojihub-class)
+* [koji::hub::x509](#kojihubx509-class)
 * [koji::kojira](#kojikojira-class)
 * [koji::utils](#kojiutils-class)
 * [koji::web](#kojiweb-class)
@@ -337,12 +338,6 @@ This manages the Koji Hub, an XML-RPC server running under mod\_wsgi in
 Apache's httpd.  It also manages Koji's skeleton file system.  The Koji Hub may
 be run on the same host as the Koji Web, but that's not required.
 
-#####  `client_ca_cert_content`, `client_ca_cert_source`
-Literal string or Puppet source URI providing the CA certificate which signed
-the client certificates that wish to connect to this Koji Hub.  This must be in
-PEM format and include all intermediate CA certificates, sorted and
-concatenated from the leaf CA to the root CA.
-
 ##### `db_host`
 Name of host that provides the Koji database.
 
@@ -354,20 +349,6 @@ The TCP port for the Koji database connection.  The default is `5432`, the stand
 
 ##### `db_user`
 User name for the Koji database connection.
-
-#####  `hub_ca_cert_content`, `hub_ca_cert_source`
-Literal string or Puppet source URI providing the CA certificate which signed
-*hub_cert_source*.  This must be in PEM format and include all intermediate CA
-certificates, sorted and concatenated from the leaf CA to the root CA.
-
-#####  `hub_cert_content`, `hub_cert_source`
-Literal string or Puppet source URI providing the Koji Hub's certificate.  This
-must be in PEM format.
-
-#####  `hub_key_content`, `hub_key_source`
-Literal string or Puppet source URI providing the private key that was used to
-sign the Koji Hub's certificate contained in *hub_cert_source*.  This must be
-in PEM format.
 
 ##### `top_dir`
 Directory containing the `'repos/'` directory.
@@ -405,6 +386,34 @@ is `'normal'`.  One of:
 The prefix the Koji Hub is to use when providing content references for access
 through the Koji Web.  The default is `'http://`*FQDN*`/koji'` where *FQDN* is
 the host's fully qualified domain name.
+
+
+#### koji::hub::x509 class
+
+This class manages the X.509 certificates on a host acting as a Koji Hub.  It's
+use is optional and should only be included if you wish to use the integrated
+X.509 support offered by the
+[doubledog-openssl](https://github.com/jflorian/doubledog-openssl) module.
+
+#####  `client_ca_cert_content`, `client_ca_cert_source`
+Literal string or Puppet source URI providing the CA certificate which signed
+the client certificates that wish to connect to this Koji Hub.  This must be in
+PEM format and include all intermediate CA certificates, sorted and
+concatenated from the leaf CA to the root CA.
+
+#####  `hub_ca_cert_content`, `hub_ca_cert_source`
+Literal string or Puppet source URI providing the CA certificate which signed
+*hub_cert_source*.  This must be in PEM format and include all intermediate CA
+certificates, sorted and concatenated from the leaf CA to the root CA.
+
+#####  `hub_cert_content`, `hub_cert_source`
+Literal string or Puppet source URI providing the Koji Hub's certificate.  This
+must be in PEM format.
+
+#####  `hub_key_content`, `hub_key_source`
+Literal string or Puppet source URI providing the private key that was used to
+sign the Koji Hub's certificate contained in *hub_cert_source*.  This must be
+in PEM format.
 
 
 #### koji::kojira class

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The typical Koji build system deployment consists of one or more Builders, a Web
 **Classes:**
 
 * [koji::builder](#kojibuilder-class)
+* [koji::builder::x509](#kojibuilderx509-class)
 * [koji::cli](#kojicli-class)
 * [koji::database](#kojidatabase-class)
 * [koji::gc](#kojigc-class)
@@ -88,16 +89,6 @@ URL of your package download site.
 
 ##### `hub`
 URL of your Koji Hub service.
-
-#####  `hub_ca_cert_content`, `hub_ca_cert_source`
-Literal string or Puppet source URI providing the CA certificate which signed
-the Koji Hub certificate.  This must be in PEM format and include all
-intermediate CA certificates, sorted and concatenated from the leaf CA to the
-root CA.
-
-#####  `kojid_cert_content`, `kojid_cert_source`
-Literal string or Puppet source URI providing the builder's identity
-certificate which must be in PEM format.
 
 ##### `top_dir`
 Name of the directory containing the `'repos/'` directory.
@@ -181,6 +172,24 @@ Enable using createrepo\_c instead of createrepo.  The default is `false`.
 ##### `work_dir`
 Name of the directory where temporary work will be performed.  The default
 is `'/tmp/koji'`.
+
+
+#### koji::builder::x509 class
+
+This class manages the X.509 certificates on a host acting as a Koji Builder.
+It's use is optional and should only be included if you wish to use the
+integrated X.509 support offered by the
+[doubledog-openssl](https://github.com/jflorian/doubledog-openssl) module.
+
+#####  `hub_ca_cert_content`, `hub_ca_cert_source`
+Literal string or Puppet source URI providing the CA certificate which signed
+the Koji Hub certificate.  This must be in PEM format and include all
+intermediate CA certificates, sorted and concatenated from the leaf CA to the
+root CA.
+
+#####  `kojid_cert_content`, `kojid_cert_source`
+Literal string or Puppet source URI providing the builder's identity
+certificate which must be in PEM format.
 
 
 #### koji::cli class

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -53,17 +53,9 @@ koji::gc::smtp_host:                localhost
 koji::gc::unprotected_keys:         []
 
 
-koji::hub::client_ca_cert_content:  null
-koji::hub::client_ca_cert_source:   null
 koji::hub::db_port:                 5432
 koji::hub::debug:                   false
 koji::hub::email_domain:            "%{facts.domain}"
-koji::hub::hub_ca_cert_content:     null
-koji::hub::hub_ca_cert_source:      null
-koji::hub::hub_cert_content:        null
-koji::hub::hub_cert_source:         null
-koji::hub::hub_key_content:         null
-koji::hub::hub_key_source:          null
 koji::hub::packages:
     - koji-hub
     - koji-hub-plugins
@@ -72,6 +64,16 @@ koji::hub::packages:
 koji::hub::plugins:                 []
 koji::hub::traceback:               normal
 koji::hub::web_url:                 "http://%{facts.fqdn}/koji"
+
+
+koji::hub::x509::client_ca_cert_content:    null
+koji::hub::x509::client_ca_cert_source:     null
+koji::hub::x509::hub_ca_cert_content:       null
+koji::hub::x509::hub_ca_cert_source:        null
+koji::hub::x509::hub_cert_content:          null
+koji::hub::x509::hub_cert_source:           null
+koji::hub::x509::hub_key_content:           null
+koji::hub::x509::hub_key_source:            null
 
 
 koji::kojira::debug:                false

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -97,11 +97,13 @@ koji::utils::ensure:                present
 
 koji::web::debug:                   false
 koji::web::hidden_users:            []
-koji::web::hub_ca_cert_content:     null
-koji::web::hub_ca_cert_source:      null
 koji::web::login_timeout:           72  # hours
 koji::web::packages:
     - koji-web
 koji::web::theme:                   default
-koji::web::web_cert_content:        null
-koji::web::web_cert_source:         null
+
+
+koji::web::x509::hub_ca_cert_content:   null
+koji::web::x509::hub_ca_cert_source:    null
+koji::web::x509::web_cert_content:      null
+koji::web::x509::web_cert_source:       null

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,11 +10,7 @@ koji::builder::debug:                       false
 koji::builder::enable:                      true
 koji::builder::ensure:                      running
 koji::builder::failed_buildroot_lifetime:   14400   # 4 hours
-koji::builder::hub_ca_cert_content:         null
-koji::builder::hub_ca_cert_source:          null
 koji::builder::image_building:              false
-koji::builder::kojid_cert_content:          null
-koji::builder::kojid_cert_source:           null
 koji::builder::min_space:                   8192    # MiB
 koji::builder::mock_dir:                    /var/lib/mock
 koji::builder::mock_user:                   kojibuilder
@@ -25,6 +21,12 @@ koji::builder::service:                     kojid
 koji::builder::smtp_host:                   localhost
 koji::builder::use_createrepo_c:            false
 koji::builder::work_dir:                    /tmp/koji
+
+
+koji::builder::x509::hub_ca_cert_content:   null
+koji::builder::x509::hub_ca_cert_source:    null
+koji::builder::x509::kojid_cert_content:    null
+koji::builder::x509::kojid_cert_source:     null
 
 
 koji::cli::packages:

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -81,11 +81,13 @@ koji::kojira::deleted_repo_lifetime:    604800  # 1 week
 koji::kojira::dist_repo_lifetime:   604800      # 1 week
 koji::kojira::enable:               true
 koji::kojira::ensure:               running
-koji::kojira::hub_ca_cert_content:  null
-koji::kojira::hub_ca_cert_source:   null
-koji::kojira::kojira_cert_content:  null
-koji::kojira::kojira_cert_source:   null
 koji::kojira::service:              kojira
+
+
+koji::kojira::x509::hub_ca_cert_content:    null
+koji::kojira::x509::hub_ca_cert_source:     null
+koji::kojira::x509::kojira_cert_content:    null
+koji::kojira::x509::kojira_cert_source:     null
 
 
 koji::utils::packages:

--- a/manifests/builder.pp
+++ b/manifests/builder.pp
@@ -17,10 +17,6 @@
 class koji::builder (
         String[1]                                    $downloads,
         String[1]                                    $hub,
-        Optional[String[1]]                          $hub_ca_cert_content,
-        Optional[String[1]]                          $hub_ca_cert_source,
-        Optional[String[1]]                          $kojid_cert_content,
-        Optional[String[1]]                          $kojid_cert_source,
         String[1]                                    $top_dir,
         Array[String[1], 1]                          $allowed_scms,
         Boolean                                      $build_arch_can_fail,
@@ -52,26 +48,6 @@ class koji::builder (
             ensure => installed,
             notify => Service[$service],
         }
-    }
-
-    # The CA certificates are correct to use openssl::tls_certificate instead
-    # of openssl::tls_ca_certificate because they don't need to be general
-    # trust anchors.
-    ::openssl::tls_certificate {
-        default:
-            cert_path => '/etc/kojid',
-            notify    => Service[$service],
-            ;
-        'kojid-hub-ca-chain':
-            cert_name    => 'hub-ca-chain',
-            cert_content => $hub_ca_cert_content,
-            cert_source  => $hub_ca_cert_source,
-            ;
-        'kojid':
-            cert_name    => 'kojid',
-            cert_content => $kojid_cert_content,
-            cert_source  => $kojid_cert_source,
-            ;
     }
 
     file {

--- a/manifests/builder/x509.pp
+++ b/manifests/builder/x509.pp
@@ -1,0 +1,46 @@
+#
+# == Class: koji::builder::x509
+#
+# Manages X.509 certificates on a host acting as a Koji Builder.
+#
+# === Authors
+#
+#   John Florian <jflorian@doubledog.org>
+#
+# === Copyright
+#
+# This file is part of the doubledog-koji Puppet module.
+# Copyright 2018 John Florian
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+class koji::builder::x509 (
+        Optional[String[1]] $hub_ca_cert_content,
+        Optional[String[1]] $hub_ca_cert_source,
+        Optional[String[1]] $kojid_cert_content,
+        Optional[String[1]] $kojid_cert_source,
+    ) {
+
+    include '::koji::builder'
+
+    # The CA certificates are correct to use openssl::tls_certificate instead
+    # of openssl::tls_ca_certificate because they don't need to be general
+    # trust anchors.
+    ::openssl::tls_certificate {
+        default:
+            cert_path => '/etc/kojid',
+            notify    => Service[$::koji::builder::service],
+            ;
+        'kojid-hub-ca-chain':
+            cert_name    => 'hub-ca-chain',
+            cert_content => $hub_ca_cert_content,
+            cert_source  => $hub_ca_cert_source,
+            ;
+        'kojid':
+            cert_name    => 'kojid',
+            cert_content => $kojid_cert_content,
+            cert_source  => $kojid_cert_source,
+            ;
+    }
+
+}

--- a/manifests/hub.pp
+++ b/manifests/hub.pp
@@ -15,18 +15,10 @@
 
 
 class koji::hub (
-        Optional[String[1]]                   $client_ca_cert_content,
-        Optional[String[1]]                   $client_ca_cert_source,
         String[1]                             $db_host,
         String[1]                             $db_passwd,
         Integer[1,65535]                      $db_port,
         String[1]                             $db_user,
-        Optional[String[1]]                   $hub_ca_cert_content,
-        Optional[String[1]]                   $hub_ca_cert_source,
-        Optional[String[1]]                   $hub_cert_content,
-        Optional[String[1]]                   $hub_cert_source,
-        Optional[String[1]]                   $hub_key_content,
-        Optional[String[1]]                   $hub_key_source,
         String[1]                             $top_dir,
         Array[String[1], 1]                   $packages,
         Array[String[1]]                      $proxy_auth_dns,
@@ -56,29 +48,6 @@ class koji::hub (
         'kojihub':
             content   => template('koji/hub/kojihub.conf.erb'),
             subscribe => Package[$packages],
-            ;
-    }
-
-    # The CA certificates are correct to use openssl::tls_certificate instead
-    # of openssl::tls_ca_certificate because they don't need to be general
-    # trust anchors.
-    ::openssl::tls_certificate {
-        default:
-            notify => Class['::apache::service'],
-            ;
-        'koji-client-ca-chain':
-            cert_content => $client_ca_cert_content,
-            cert_source  => $client_ca_cert_source,
-            ;
-        'koji-hub-ca-chain':
-            cert_content => $hub_ca_cert_content,
-            cert_source  => $hub_ca_cert_source,
-            ;
-        'koji-hub':
-            cert_content => $hub_cert_content,
-            cert_source  => $hub_cert_source,
-            key_content  => $hub_key_content,
-            key_source   => $hub_key_source,
             ;
     }
 

--- a/manifests/hub/x509.pp
+++ b/manifests/hub/x509.pp
@@ -1,0 +1,51 @@
+#
+# == Class: koji::hub::x509
+#
+# Manages the X.509 certificates for the Koji Hub component on a host.
+#
+# === Authors
+#
+#   John Florian <jflorian@doubledog.org>
+#
+# === Copyright
+#
+# This file is part of the doubledog-koji Puppet module.
+# Copyright 2018 John Florian
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+class koji::hub::x509 (
+        Optional[String[1]]                   $client_ca_cert_content,
+        Optional[String[1]]                   $client_ca_cert_source,
+        Optional[String[1]]                   $hub_ca_cert_content,
+        Optional[String[1]]                   $hub_ca_cert_source,
+        Optional[String[1]]                   $hub_cert_content,
+        Optional[String[1]]                   $hub_cert_source,
+        Optional[String[1]]                   $hub_key_content,
+        Optional[String[1]]                   $hub_key_source,
+    ) {
+
+    # The CA certificates are correct to use openssl::tls_certificate instead
+    # of openssl::tls_ca_certificate because they don't need to be general
+    # trust anchors.
+    ::openssl::tls_certificate {
+        default:
+            notify => Class['::apache::service'],
+            ;
+        'koji-client-ca-chain':
+            cert_content => $client_ca_cert_content,
+            cert_source  => $client_ca_cert_source,
+            ;
+        'koji-hub-ca-chain':
+            cert_content => $hub_ca_cert_content,
+            cert_source  => $hub_ca_cert_source,
+            ;
+        'koji-hub':
+            cert_content => $hub_cert_content,
+            cert_source  => $hub_cert_source,
+            key_content  => $hub_key_content,
+            key_source   => $hub_key_source,
+            ;
+    }
+
+}

--- a/manifests/kojira.pp
+++ b/manifests/kojira.pp
@@ -16,10 +16,6 @@
 
 class koji::kojira (
         String[1]                                    $hub,
-        Optional[String[1]]                          $hub_ca_cert_content,
-        Optional[String[1]]                          $hub_ca_cert_source,
-        Optional[String[1]]                          $kojira_cert_content,
-        Optional[String[1]]                          $kojira_cert_source,
         String[1]                                    $top_dir,
         Boolean                                      $debug,
         Integer[0]                                   $deleted_repo_lifetime,
@@ -30,26 +26,6 @@ class koji::kojira (
     ) {
 
     include '::koji::utils'
-
-    # The CA certificates are correct to use openssl::tls_certificate instead
-    # of openssl::tls_ca_certificate because they don't need to be general
-    # trust anchors.
-    ::openssl::tls_certificate {
-        default:
-            cert_path => '/etc/kojira',
-            notify    => Service[$service],
-            ;
-        'kojira-hub-ca-chain':
-            cert_name    => 'hub-ca-chain',
-            cert_content => $hub_ca_cert_content,
-            cert_source  => $hub_ca_cert_source,
-            ;
-        'kojira':
-            cert_name    => 'kojira',
-            cert_content => $kojira_cert_content,
-            cert_source  => $kojira_cert_source,
-            ;
-    }
 
     file { '/etc/kojira/kojira.conf':
         owner     => 'root',

--- a/manifests/kojira/x509.pp
+++ b/manifests/kojira/x509.pp
@@ -1,0 +1,46 @@
+#
+# == Class: koji::kojira::x509
+#
+# Manages the X.509 certificates for the Koji Kojira component on a host.
+#
+# === Authors
+#
+#   John Florian <jflorian@doubledog.org>
+#
+# === Copyright
+#
+# This file is part of the doubledog-koji Puppet module.
+# Copyright 2018 John Florian
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+class koji::kojira::x509 (
+        Optional[String[1]] $hub_ca_cert_content,
+        Optional[String[1]] $hub_ca_cert_source,
+        Optional[String[1]] $kojira_cert_content,
+        Optional[String[1]] $kojira_cert_source,
+    ) {
+
+    include '::koji::kojira'
+
+    # The CA certificates are correct to use openssl::tls_certificate instead
+    # of openssl::tls_ca_certificate because they don't need to be general
+    # trust anchors.
+    ::openssl::tls_certificate {
+        default:
+            cert_path => '/etc/kojira',
+            notify    => Service[$::koji::kojira::service],
+            ;
+        'kojira-hub-ca-chain':
+            cert_name    => 'hub-ca-chain',
+            cert_content => $hub_ca_cert_content,
+            cert_source  => $hub_ca_cert_source,
+            ;
+        'kojira':
+            cert_name    => 'kojira',
+            cert_content => $kojira_cert_content,
+            cert_source  => $kojira_cert_source,
+            ;
+    }
+
+}

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -16,12 +16,8 @@
 
 class koji::web (
         String[1]           $files_url,
-        Optional[String[1]] $hub_ca_cert_content,
-        Optional[String[1]] $hub_ca_cert_source,
         String[1]           $hub_url,
         String[1]           $secret,
-        Optional[String[1]] $web_cert_content,
-        Optional[String[1]] $web_cert_source,
         Boolean             $debug,
         Array[Integer]      $hidden_users,
         Integer             $login_timeout,
@@ -39,26 +35,6 @@ class koji::web (
         'kojiweb':
             content   => template('koji/web/kojiweb.conf.erb'),
             subscribe => Package[$packages],
-            ;
-    }
-
-    # The CA certificates are correct to use openssl::tls_certificate instead
-    # of openssl::tls_ca_certificate because they don't need to be general
-    # trust anchors.
-    ::openssl::tls_certificate {
-        default:
-            cert_path => '/etc/kojiweb',
-            notify    => Class['::apache::service'],
-            ;
-        'kojiweb-hub-ca-chain':
-            cert_name    => 'hub-ca-chain',
-            cert_content => $hub_ca_cert_content,
-            cert_source  => $hub_ca_cert_source,
-            ;
-        'kojiweb':
-            cert_name    => 'web',
-            cert_content => $web_cert_content,
-            cert_source  => $web_cert_source,
             ;
     }
 

--- a/manifests/web/x509.pp
+++ b/manifests/web/x509.pp
@@ -1,0 +1,46 @@
+#
+# == Class: koji::web::x509
+#
+# Manages the X.509 certificates for the Koji Web component on a host.
+#
+# === Authors
+#
+#   John Florian <jflorian@doubledog.org>
+#
+# === Copyright
+#
+# This file is part of the doubledog-koji Puppet module.
+# Copyright 2018 John Florian
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+class koji::web::x509 (
+        Optional[String[1]] $hub_ca_cert_content,
+        Optional[String[1]] $hub_ca_cert_source,
+        Optional[String[1]] $web_cert_content,
+        Optional[String[1]] $web_cert_source,
+    ) {
+
+    include '::koji::web'
+
+    # The CA certificates are correct to use openssl::tls_certificate instead
+    # of openssl::tls_ca_certificate because they don't need to be general
+    # trust anchors.
+    ::openssl::tls_certificate {
+        default:
+            cert_path => '/etc/kojiweb',
+            notify    => Class['::apache::service'],
+            ;
+        'kojiweb-hub-ca-chain':
+            cert_name    => 'hub-ca-chain',
+            cert_content => $hub_ca_cert_content,
+            cert_source  => $hub_ca_cert_source,
+            ;
+        'kojiweb':
+            cert_name    => 'web',
+            cert_content => $web_cert_content,
+            cert_source  => $web_cert_source,
+            ;
+    }
+
+}


### PR DESCRIPTION
Per #3, this makes all aspects of using X.509 optional for Koji with this module.  It paves the way for doing proper Kerberos support, as an alternative.