### PR TITLE
Update version info for postgresql dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,7 @@
         },
         {
             "name": "puppetlabs/postgresql",
-            "version_requirement": ">= 5.0.0 < 6.0.0"
+            "version_requirement": ">= 5.0.0 < 7.0.0"
         },
         {
             "name": "puppetlabs/stdlib",


### PR DESCRIPTION
puppetlabs-postgresql 6.1 has been released.  This fixes the warnings
issued by the puppet module report.  For example:

```
Warning: Module 'puppetlabs-postgresql' (v6.1.0) fails to meet some dependencies:
  'doubledog-koji' (v4.2.0) requires 'puppetlabs-postgresql' (>= 5.0.0 < 6.0.0)
```